### PR TITLE
BUG Report (no issues page)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -18,7 +18,7 @@ networks. Hum Brain Mapp. 2019; 1–13. https://doi.org/10.1002/hbm.24750
     cd HD-CTBET
     pip install -e .
     ```
-3) Per default, model parameters will be downloaded from [zenodo](https://zenodo.org/record/7970359) to ~/hd-bet_params. If you wish to use a different folder, open
+3) Per default, model parameters will be downloaded from [zenodo](https://zenodo.org/records/7973721) to ~/hd-bet_params. If you wish to use a different folder, open
 HD_CTBET/paths.py in a text editor and modify ```folder_with_parameter_files```
 
 

--- a/readme.md
+++ b/readme.md
@@ -63,3 +63,5 @@ For more information, please refer to the help functionality:
 ```bash
 hd-ctbet --help
 ```
+
+You need the `nnUNetTrainerV2Wandb` trainer


### PR DESCRIPTION
I'm getting the following errors but there is no issues page for this, but I'm getting this error:
```
RuntimeError: Could not find the model trainer specified in checkpoint in nnunet.trainig.network_training. If it is not located there, please move it or change the code of restore_model. Your model trainer can be located in any directory within nnunet.trainig.network_training (search is recursive).
Debug info: 
checkpoint file: None
Name of trainer: nnUNetTrainerV2Wandb 
```

From `CT_0.model.pkl'` you have `init`
```
('/homes/claes/projects/nnUNet/nnUNet_processed/Task206_CTBET/nnUNetPlansv2.1_plans_3D.pkl', 0, '/homes/claes/projects/nnUNet/nnUNet_trained_models/nnUNet/3d_fullres/Task206_CTBET/nnUNetTrainerV2Wandb__nnUNetPlansv2.1', '/homes/claes/projects/nnUNet/nnUNet_processed/Task206_CTBET', True, 1, True, False, True)
```
I don't know how to get `nnUNetTrainerV2Wandb` initialized.